### PR TITLE
Add DVC for binary data and model versioning

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,5 @@
 [core]
     remote = s3remote
 ['remote "s3remote"']
-    url = s3://PLACEHOLDER-BUCKET/bullet-prove
+    url = s3://bullet-prove-data-490954040359-us-east-1-an/bullet-prove/
+    region = us-east-1

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,4 @@
+[core]
+    remote = s3remote
+['remote "s3remote"']
+    url = s3://PLACEHOLDER-BUCKET/bullet-prove

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ out/
 checkpoints/
 net_structure.png
 *.bak
+/data2
+/data3
+/checkpoints

--- a/README.dvc.md
+++ b/README.dvc.md
@@ -1,0 +1,79 @@
+# DVC Setup
+
+[DVC](https://dvc.org) is used to version and share binary assets that are too
+large for git: real target photos (`data2/`, `data3/`) and trained model
+checkpoints (`checkpoints/`). Git stores small `.dvc` pointer files; the actual
+data lives in S3.
+
+## Install
+
+```bash
+pip install "dvc[s3]"
+```
+
+The `[s3]` extra pulls in `boto3` for AWS S3 access. If you installed the
+project dependencies via `pip install -r requirements.txt` first, only the
+`dvc[s3]` package is needed on top.
+
+## AWS credentials
+
+DVC uses the standard AWS credential chain. Any of the following works:
+
+**Option A — AWS credentials file** (recommended for local dev)
+
+```bash
+aws configure   # requires the AWS CLI
+```
+
+This writes `~/.aws/credentials`. If you don't have the AWS CLI, create the
+file manually:
+
+```ini
+[default]
+aws_access_key_id     = AKIA...
+aws_secret_access_key = ...
+region                = us-east-1
+```
+
+**Option B — environment variables**
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_DEFAULT_REGION=us-east-1
+```
+
+**Option C — DVC local config** (credentials stay on this machine, never committed)
+
+```bash
+dvc remote modify --local s3remote access_key_id AKIA...
+dvc remote modify --local s3remote secret_access_key ...
+```
+
+## Download data (after cloning)
+
+```bash
+dvc pull
+```
+
+This fetches `data2/`, `data3/`, and `checkpoints/` from S3.
+
+## Upload new or changed data
+
+```bash
+dvc add data2/          # update the pointer file after adding new images
+git add data2.dvc
+git commit -m "Add new target photos"
+dvc push                # upload to S3
+git push
+```
+
+## Remote configuration
+
+The default remote is `s3remote`:
+
+```
+s3://bullet-prove-data-490954040359-us-east-1-an/bullet-prove/
+```
+
+See `.dvc/config` for the full configuration.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ source .venv/bin/activate        # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
+For DVC setup (binary data and model versioning via S3) see [README.dvc.md](README.dvc.md).
+
 ## ML pipeline
 
 ### 1. Generate training data

--- a/checkpoints.dvc
+++ b/checkpoints.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 2fca0c799070af912bf5947c766b1e18.dir
+  size: 46728797
+  nfiles: 2
+  hash: md5
+  path: checkpoints

--- a/data2.dvc
+++ b/data2.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: d52e0b061e0fecea94b92f89c8e81e6c.dir
+  size: 7442416
+  nfiles: 11
+  hash: md5
+  path: data2

--- a/data3.dvc
+++ b/data3.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 3b1ffef01a3d1545c2e8c6e4dc555d28.dir
+  size: 47229405
+  nfiles: 1
+  hash: md5
+  path: data3


### PR DESCRIPTION
## Summary

- Initialize DVC repository and configure S3 remote (`s3://bullet-prove-data-490954040359-us-east-1-an/bullet-prove/`, `us-east-1`)
- Track `data2/`, `data3/` (real target photos) and `checkpoints/` (trained models) via DVC pointer files — binaries no longer need to be in git
- Add `README.dvc.md` with installation, AWS credential options, and pull/push workflow
- Add reference to `README.dvc.md` in main `README.md`

## Test plan

- [ ] `pip install "dvc[s3]"` installs without errors
- [ ] `dvc pull` restores `data2/`, `data3/`, `checkpoints/` after a fresh clone
- [ ] `dvc push` uploads new or changed files to S3

🤖 Generated with [Claude Code](https://claude.ai/claude-code)